### PR TITLE
Added content and background scripts

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -9,5 +9,18 @@
   "chrome_url_overrides": {
     "newtab": "src/new-tab/index.html"
   },
-  "permissions": ["storage"]
+  "permissions": ["storage"],
+  "options_ui": {
+    "page": "src/options/index.html",
+    "open_in_tab": true
+  },
+  "content_scripts": [
+    {
+        "matches": ["https://*/*"],
+        "js": ["src/content/index.ts"]
+    }
+  ],
+  "background": {
+    "service_worker": "src/background/index.ts"
+  }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -10,10 +10,6 @@
     "newtab": "src/new-tab/index.html"
   },
   "permissions": ["storage"],
-  "options_ui": {
-    "page": "src/options/index.html",
-    "open_in_tab": true
-  },
   "content_scripts": [
     {
         "matches": ["https://*/*"],

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,0 +1,1 @@
+console.log("From background script")

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -1,0 +1,1 @@
+console.log("From content script")


### PR DESCRIPTION
Hi there! I've been using this template to build some personal extensions with svelte + tailwind and thought it might be nice add support for content and background scripts to this template. I added it as a seperate branch called "04-scripts"